### PR TITLE
Tehtävät tehty

### DIFF
--- a/src/training_day.clj
+++ b/src/training_day.clj
@@ -1,11 +1,18 @@
 (ns training-day)
 
-(def answer ":(")
+(def answer 42)
 
 (def hai "O HAI!")
 
-(defn square [x]
-  ":(")
+(defn 
+  square 
+  "Multiplies a number by itself"
+  [x] 
+  (* x x))
 
-(defn average [a b]
-  ":(")
+(defn 
+  average
+  "Returns the average of it's parameters"
+  [a b]
+  (/ (+ a b) 2)
+)


### PR DESCRIPTION
Ensin tekninen huomautus. En ole varma oliko vaan mun koneella mutta funktio:
(authors books)
määriteltiin funktion: all-author-names books jälkeen. Eli jos edellistä yritti käyttää jälkimmäisen ratkaisussa homma ei toimi. 

Toinen kysymys:

Harrastaako Clojure Haskelin tapaista "Curryingiä". Eli kun askelissa "+" on funktio Int -> Int -> Int (ottaa kaksi koknaislukua palauttaa yhden) niin "+ 2" on funktio Int -> Int (Ottaa yhden luvun, laskee siihen yhteen kakkosen ja palauttaa tuloksen). 

Toimiiko samalla lailla vai pitääkö kaikki mapit ja filterit aina määritellä fn:än kautta?
